### PR TITLE
[已关闭] Resolve #4: Write unit tests for all API endpoints - 合并到 main

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "supertest": "^6.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,263 @@
-// Placeholder - will be implemented by Copilot
-console.log('Automated Workflow Demo');
+const express = require('express');
+const { v4: uuidv4 } = require('uuid');
 
-module.exports = {};
+/**
+ * Express 应用实例
+ * @type {express.Application}
+ */
+const app = express();
+
+/**
+ * 服务器端口
+ * @type {number}
+ */
+const PORT = process.env.PORT || 3000;
+
+/**
+ * 任务存储（内存数组）
+ * @type {Array<Object>}
+ */
+const tasks = [];
+
+// 配置中间件
+app.use(express.json()); // JSON body parser
+app.use(express.urlencoded({ extended: true })); // URL-encoded body parser
+
+/**
+ * 验证任务输入数据
+ * @param {Object} data - 要验证的数据
+ * @param {boolean} isUpdate - 是否为更新操作
+ * @returns {Object} 验证结果 { valid: boolean, error?: string }
+ */
+const validateTaskInput = (data, isUpdate = false) => {
+  const { title, description, completed } = data;
+
+  // 创建操作时，title 必填
+  if (!isUpdate && !title) {
+    return { valid: false, error: 'Title is required' };
+  }
+
+  // 验证 title
+  if (title !== undefined) {
+    if (typeof title !== 'string' || title.trim().length === 0) {
+      return { valid: false, error: 'Title must be a non-empty string' };
+    }
+    if (title.length > 100) {
+      return { valid: false, error: 'Title must be 100 characters or less' };
+    }
+  }
+
+  // 验证 description
+  if (description !== undefined) {
+    if (typeof description !== 'string') {
+      return { valid: false, error: 'Description must be a string' };
+    }
+    if (description.length > 500) {
+      return { valid: false, error: 'Description must be 500 characters or less' };
+    }
+  }
+
+  // 验证 completed
+  if (completed !== undefined) {
+    if (typeof completed !== 'boolean') {
+      return { valid: false, error: 'Completed must be a boolean' };
+    }
+  }
+
+  return { valid: true };
+};
+
+/**
+ * 统一错误处理中间件
+ * @param {Error} err - 错误对象
+ * @param {express.Request} req - 请求对象
+ * @param {express.Response} res - 响应对象
+ * @param {Function} next - 下一个中间件函数
+ */
+const errorHandler = (err, req, res, next) => {
+  console.error('Error:', err);
+
+  // 处理 JSON 解析错误
+  if (err instanceof SyntaxError && err.status === 400 && 'body' in err) {
+    return res.status(400).json({
+      error: 'Invalid JSON',
+      details: 'Request body contains invalid JSON'
+    });
+  }
+
+  // 默认服务器错误
+  res.status(err.status || 500).json({
+    error: err.message || 'Internal Server Error',
+    details: process.env.NODE_ENV === 'development' ? err.stack : {}
+  });
+};
+
+/**
+ * 健康检查路由
+ * @route GET /
+ * @returns {Object} 200 - 服务状态对象
+ */
+app.get('/', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+/**
+ * 创建新任务
+ * @route POST /api/tasks
+ * @param {string} req.body.title - 任务标题（必填，最大100字符）
+ * @param {string} [req.body.description] - 任务描述（可选，最大500字符）
+ * @returns {Object} 201 - 创建的任务对象
+ * @returns {Object} 400 - 验证错误
+ */
+app.post('/api/tasks', (req, res) => {
+  const { title, description } = req.body;
+  
+  // 输入验证
+  const validation = validateTaskInput(req.body, false);
+  if (!validation.valid) {
+    return res.status(400).json({ error: validation.error });
+  }
+  
+  // 创建新任务
+  const newTask = {
+    id: uuidv4(),
+    title: title.trim(),
+    description: description ? description.trim() : '',
+    completed: false,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+  
+  // 添加到存储
+  tasks.push(newTask);
+  
+  res.status(201).json(newTask);
+});
+
+/**
+ * 获取所有任务
+ * @route GET /api/tasks
+ * @returns {Array<Object>} 200 - 任务数组
+ */
+app.get('/api/tasks', (req, res) => {
+  res.status(200).json(tasks);
+});
+
+/**
+ * 获取单个任务
+ * @route GET /api/tasks/:id
+ * @param {string} req.params.id - 任务ID
+ * @returns {Object} 200 - 任务对象
+ * @returns {Object} 404 - 任务未找到
+ */
+app.get('/api/tasks/:id', (req, res) => {
+  const { id } = req.params;
+  
+  // 验证 ID 格式（简单的 UUID 格式检查）
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ error: 'Invalid task ID format' });
+  }
+  
+  const task = tasks.find(t => t.id === id);
+  
+  if (!task) {
+    return res.status(404).json({ error: 'Task not found' });
+  }
+  
+  res.status(200).json(task);
+});
+
+/**
+ * 更新任务
+ * @route PATCH /api/tasks/:id
+ * @param {string} req.params.id - 任务ID
+ * @param {string} [req.body.title] - 新的任务标题
+ * @param {string} [req.body.description] - 新的任务描述
+ * @param {boolean} [req.body.completed] - 新的完成状态
+ * @returns {Object} 200 - 更新后的任务对象
+ * @returns {Object} 400 - 验证错误
+ * @returns {Object} 404 - 任务未找到
+ */
+app.patch('/api/tasks/:id', (req, res) => {
+  const { id } = req.params;
+  const { title, description, completed } = req.body;
+  
+  // 验证 ID 格式
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ error: 'Invalid task ID format' });
+  }
+  
+  // 检查请求体是否为空
+  if (Object.keys(req.body).length === 0) {
+    return res.status(400).json({ error: 'Request body cannot be empty' });
+  }
+  
+  // 输入验证
+  const validation = validateTaskInput(req.body, true);
+  if (!validation.valid) {
+    return res.status(400).json({ error: validation.error });
+  }
+  
+  const taskIndex = tasks.findIndex(t => t.id === id);
+  
+  if (taskIndex === -1) {
+    return res.status(404).json({ error: 'Task not found' });
+  }
+  
+  // 更新任务字段
+  const task = tasks[taskIndex];
+  if (title !== undefined) task.title = title.trim();
+  if (description !== undefined) task.description = description.trim();
+  if (completed !== undefined) task.completed = completed;
+  task.updatedAt = new Date();
+  
+  res.status(200).json(task);
+});
+
+/**
+ * 删除任务
+ * @route DELETE /api/tasks/:id
+ * @param {string} req.params.id - 任务ID
+ * @returns {void} 204 - 无内容
+ * @returns {Object} 404 - 任务未找到
+ */
+app.delete('/api/tasks/:id', (req, res) => {
+  const { id } = req.params;
+  
+  // 验证 ID 格式
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ error: 'Invalid task ID format' });
+  }
+  
+  const taskIndex = tasks.findIndex(t => t.id === id);
+  
+  if (taskIndex === -1) {
+    return res.status(404).json({ error: 'Task not found' });
+  }
+  
+  // 删除任务
+  tasks.splice(taskIndex, 1);
+  
+  res.status(204).send();
+});
+
+// 404 处理 - 未找到路由
+app.use((req, res) => {
+  res.status(404).json({ error: 'Route not found' });
+});
+
+// 注册全局错误处理中间件
+app.use(errorHandler);
+
+/**
+ * 启动服务器
+ * @listens {number} PORT - 服务器监听端口
+ */
+const server = app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});
+
+/**
+ * 导出 app 和 server 用于测试
+ */
+module.exports = { app, server, tasks, validateTaskInput };

--- a/tests/tasks.test.js
+++ b/tests/tasks.test.js
@@ -1,0 +1,297 @@
+const request = require('supertest');
+const { app, server, tasks } = require('../src/index');
+
+/**
+ * Tasks API 单元测试
+ */
+describe('Tasks API', () => {
+  // 每个测试前清空任务数组
+  beforeEach(() => {
+    tasks.length = 0;
+  });
+
+  // 测试结束后关闭服务器
+  afterAll(() => {
+    server.close();
+  });
+
+  describe('POST /api/tasks', () => {
+    it('should create a new task successfully', async () => {
+      const response = await request(app)
+        .post('/api/tasks')
+        .send({
+          title: 'Test Task',
+          description: 'Test Description'
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.title).toBe('Test Task');
+      expect(response.body.description).toBe('Test Description');
+      expect(response.body.completed).toBe(false);
+      expect(response.body).toHaveProperty('createdAt');
+      expect(response.body).toHaveProperty('updatedAt');
+    });
+
+    it('should fail when title is missing', async () => {
+      const response = await request(app)
+        .post('/api/tasks')
+        .send({
+          description: 'Test Description'
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(response.body.error).toContain('Title is required');
+    });
+
+    it('should fail when title exceeds 100 characters', async () => {
+      const response = await request(app)
+        .post('/api/tasks')
+        .send({
+          title: 'a'.repeat(101)
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('100 characters or less');
+    });
+
+    it('should fail when description exceeds 500 characters', async () => {
+      const response = await request(app)
+        .post('/api/tasks')
+        .send({
+          title: 'Test Task',
+          description: 'a'.repeat(501)
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('500 characters or less');
+    });
+
+    it('should trim whitespace from title and description', async () => {
+      const response = await request(app)
+        .post('/api/tasks')
+        .send({
+          title: '  Test Task  ',
+          description: '  Test Description  '
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.title).toBe('Test Task');
+      expect(response.body.description).toBe('Test Description');
+    });
+  });
+
+  describe('GET /api/tasks', () => {
+    it('should return empty array when no tasks exist', async () => {
+      const response = await request(app)
+        .get('/api/tasks');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([]);
+    });
+
+    it('should return array with multiple tasks', async () => {
+      // 创建多个任务
+      await request(app)
+        .post('/api/tasks')
+        .send({ title: 'Task 1' });
+      
+      await request(app)
+        .post('/api/tasks')
+        .send({ title: 'Task 2' });
+
+      const response = await request(app)
+        .get('/api/tasks');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveLength(2);
+      expect(response.body[0].title).toBe('Task 1');
+      expect(response.body[1].title).toBe('Task 2');
+    });
+  });
+
+  describe('GET /api/tasks/:id', () => {
+    it('should return a task when it exists', async () => {
+      // 创建一个任务
+      const createResponse = await request(app)
+        .post('/api/tasks')
+        .send({ title: 'Test Task' });
+
+      const taskId = createResponse.body.id;
+
+      const response = await request(app)
+        .get(`/api/tasks/${taskId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.id).toBe(taskId);
+      expect(response.body.title).toBe('Test Task');
+    });
+
+    it('should return 404 when task does not exist', async () => {
+      const response = await request(app)
+        .get('/api/tasks/non-existent-id');
+
+      expect(response.status).toBe(404);
+      expect(response.body).toHaveProperty('error');
+      expect(response.body.error).toContain('not found');
+    });
+  });
+
+  describe('PATCH /api/tasks/:id', () => {
+    it('should update a task successfully', async () => {
+      // 创建一个任务
+      const createResponse = await request(app)
+        .post('/api/tasks')
+        .send({ title: 'Original Title' });
+
+      const taskId = createResponse.body.id;
+
+      const response = await request(app)
+        .patch(`/api/tasks/${taskId}`)
+        .send({ title: 'Updated Title' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.title).toBe('Updated Title');
+      expect(response.body).toHaveProperty('updatedAt');
+    });
+
+    it('should return 404 when task does not exist', async () => {
+      const response = await request(app)
+        .patch('/api/tasks/non-existent-id')
+        .send({ title: 'Updated Title' });
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toContain('not found');
+    });
+
+    it('should support partial field updates', async () => {
+      // 创建一个任务
+      const createResponse = await request(app)
+        .post('/api/tasks')
+        .send({ 
+          title: 'Original Title',
+          description: 'Original Description'
+        });
+
+      const taskId = createResponse.body.id;
+
+      // 只更新 completed 字段
+      const response = await request(app)
+        .patch(`/api/tasks/${taskId}`)
+        .send({ completed: true });
+
+      expect(response.status).toBe(200);
+      expect(response.body.title).toBe('Original Title');
+      expect(response.body.description).toBe('Original Description');
+      expect(response.body.completed).toBe(true);
+    });
+
+    it('should fail with empty request body', async () => {
+      // 创建一个任务
+      const createResponse = await request(app)
+        .post('/api/tasks')
+        .send({ title: 'Test Task' });
+
+      const taskId = createResponse.body.id;
+
+      const response = await request(app)
+        .patch(`/api/tasks/${taskId}`)
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('cannot be empty');
+    });
+
+    it('should fail when title exceeds 100 characters', async () => {
+      // 创建一个任务
+      const createResponse = await request(app)
+        .post('/api/tasks')
+        .send({ title: 'Test Task' });
+
+      const taskId = createResponse.body.id;
+
+      const response = await request(app)
+        .patch(`/api/tasks/${taskId}`)
+        .send({ title: 'a'.repeat(101) });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('100 characters or less');
+    });
+  });
+
+  describe('DELETE /api/tasks/:id', () => {
+    it('should delete a task successfully', async () => {
+      // 创建一个任务
+      const createResponse = await request(app)
+        .post('/api/tasks')
+        .send({ title: 'Test Task' });
+
+      const taskId = createResponse.body.id;
+
+      const response = await request(app)
+        .delete(`/api/tasks/${taskId}`);
+
+      expect(response.status).toBe(204);
+
+      // 确认任务已删除
+      const getResponse = await request(app)
+        .get(`/api/tasks/${taskId}`);
+      
+      expect(getResponse.status).toBe(404);
+    });
+
+    it('should return 404 when task does not exist', async () => {
+      const response = await request(app)
+        .delete('/api/tasks/non-existent-id');
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toContain('not found');
+    });
+  });
+
+  describe('Input Validation', () => {
+    it('should reject empty title', async () => {
+      const response = await request(app)
+        .post('/api/tasks')
+        .send({ title: '   ' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('non-empty string');
+    });
+
+    it('should reject non-string title', async () => {
+      const response = await request(app)
+        .post('/api/tasks')
+        .send({ title: 123 });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('non-empty string');
+    });
+
+    it('should reject non-boolean completed', async () => {
+      const createResponse = await request(app)
+        .post('/api/tasks')
+        .send({ title: 'Test Task' });
+
+      const taskId = createResponse.body.id;
+
+      const response = await request(app)
+        .patch(`/api/tasks/${taskId}`)
+        .send({ completed: 'yes' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('boolean');
+    });
+  });
+
+  describe('GET /', () => {
+    it('should return health check status', async () => {
+      const response = await request(app)
+        .get('/');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ status: 'ok' });
+    });
+  });
+});


### PR DESCRIPTION
## 🔀 已合并到 main 分支

此 PR 的所有更改已手动合并到 main 分支，包含：
- ✅ 完整的 CRUD API 实现
- ✅ 输入验证和错误处理
- ✅ 单元测试（20个测试用例）
- ✅ 依赖版本锁定

### 合并说明

由于多个 PR 之间存在合并冲突（都基于同一个旧的 main 分支），已手动将最完整的实现（PR #8）合并到 main 分支。

此 PR 现已关闭。

---

🤖 由 Claude Code 自动关闭